### PR TITLE
Refactor context

### DIFF
--- a/src/contexts/userContext.tsx
+++ b/src/contexts/userContext.tsx
@@ -1,6 +1,5 @@
-import React, { createContext, FunctionComponent } from 'react';
-import usePersistStorage from 'react-native-use-persist-storage';
 import { StorageKey } from '@/constant';
+import { createPersistContext } from '@/utils/context';
 
 export type TUser = {
   id: string;
@@ -8,41 +7,17 @@ export type TUser = {
   name: string;
 };
 
-export type TUserContext = {
-  user: TUser;
-  updateUser: React.Dispatch<React.SetStateAction<TUser>>;
-  restored: boolean;
-};
-
-export const createDefaultUser: () => TUser = () => ({
-  id: '',
-  email: 'test@test.com',
-  name: '',
-});
-
-export const UserContext = createContext<TUserContext>({
-  user: createDefaultUser(),
-  updateUser: () => {
-    return;
+const {
+  Context: UserContext,
+  Provider: UserProvider,
+  useData: useUser,
+} = createPersistContext({
+  defaultData: {
+    id: '',
+    email: 'test@test.com',
+    name: '',
   },
-  restored: false,
+  storageKey: StorageKey.User,
 });
 
-type TProps = { persist?: boolean };
-
-export const UserProvider: FunctionComponent<TProps> = props => {
-  const [user, setUser, restored] = usePersistStorage<TUser>(
-    StorageKey.User,
-    createDefaultUser,
-    {
-      persist: props.persist,
-      version: 0,
-    },
-  );
-
-  return (
-    <UserContext.Provider value={{ user, updateUser: setUser, restored }}>
-      {props.children}
-    </UserContext.Provider>
-  );
-};
+export { UserContext, UserProvider, useUser };

--- a/src/screens/Auth/LoginScreen.tsx
+++ b/src/screens/Auth/LoginScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState } from 'react';
 import {
   SafeAreaView,
   Text,
@@ -9,12 +9,12 @@ import {
 import { NavigationScreenProps } from 'react-navigation';
 
 import Input from '@/components/Input';
-import { UserContext } from '@/contexts/userContext';
+import { useUser } from '@/contexts/userContext';
 import { Routes } from '@/navigators/routes';
 
 type TProps = {} & NavigationScreenProps;
 const LoginScreen: React.FC<TProps> = ({ navigation }) => {
-  const { updateUser } = useContext(UserContext);
+  const { setData: setUser } = useUser();
   const [name, setName] = useState<string>('');
   return (
     <SafeAreaView style={{ flex: 1 }}>
@@ -37,7 +37,7 @@ const LoginScreen: React.FC<TProps> = ({ navigation }) => {
         <TouchableOpacity
           onPress={() => {
             navigation.navigate(Routes.MainHome);
-            updateUser(user => ({ ...user, name }));
+            setUser(user => ({ ...user, name }));
           }}
         >
           <Text style={{ textDecorationLine: 'underline' }}>Go Main</Text>

--- a/src/screens/Auth/LoginScreen.tsx
+++ b/src/screens/Auth/LoginScreen.tsx
@@ -14,7 +14,7 @@ import { Routes } from '@/navigators/routes';
 
 type TProps = {} & NavigationScreenProps;
 const LoginScreen: React.FC<TProps> = ({ navigation }) => {
-  const { setData: setUser } = useUser();
+  const [, setUser ] = useUser();
   const [name, setName] = useState<string>('');
   return (
     <SafeAreaView style={{ flex: 1 }}>

--- a/src/screens/Main/HomeScreen.tsx
+++ b/src/screens/Main/HomeScreen.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
 import { NavigationScreenProps } from 'react-navigation';
 import Spinner from '@/components/Spinner';
-import { UserContext } from '@/contexts/userContext';
+import { useUser } from '@/contexts/userContext';
 
 const HomeScreen: React.FC<NavigationScreenProps> = ({ navigation }) => {
-  const { user, restored } = useContext(UserContext);
+  const { data: user, restored } = useUser();
   return (
     <SafeAreaView
       style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}

--- a/src/screens/Main/HomeScreen.tsx
+++ b/src/screens/Main/HomeScreen.tsx
@@ -5,7 +5,7 @@ import Spinner from '@/components/Spinner';
 import { useUser } from '@/contexts/userContext';
 
 const HomeScreen: React.FC<NavigationScreenProps> = ({ navigation }) => {
-  const { data: user, restored } = useUser();
+  const [user,, restored ] = useUser();
   return (
     <SafeAreaView
       style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -18,30 +18,24 @@ export const createPersistContext = <T extends {}>({
 }) => {
   const createDefaultData = () => defaultData;
 
-  const Context = React.createContext<TPersistContext<T>>({
-    data: createDefaultData(),
-    setData: () => {
+  const Context = React.createContext<TPersistContext<T>>([
+    createDefaultData(),
+    () => {
       return;
     },
-    restored: false,
-  });
+    false,
+  ]);
 
   const Provider: React.FC<{
     persist?: boolean;
   }> = props => {
-    const [data, setData, restored] = usePersistStorage<T>(
-      storageKey,
-      createDefaultData,
-      {
-        persist: props.persist,
-        version,
-      },
-    );
+    const persisted = usePersistStorage<T>(storageKey, createDefaultData, {
+      persist: props.persist,
+      version,
+    });
 
     return (
-      <Context.Provider value={{ data, setData, restored }}>
-        {props.children}
-      </Context.Provider>
+      <Context.Provider value={persisted}>{props.children}</Context.Provider>
     );
   };
 
@@ -52,13 +46,7 @@ export const createPersistContext = <T extends {}>({
         `Context error: context [${storageKey}] must be used within a Provider`,
       );
     }
-    const { data, setData, restored } = context;
-
-    return {
-      data,
-      setData,
-      restored,
-    };
+    return context;
   };
 
   return {
@@ -75,21 +63,17 @@ export type TContext<T> = {
 
 export const createContext = <T extends {}>(defaultData: T) => {
   const createDefaultData = () => defaultData;
-  const Context = React.createContext<TContext<T>>({
-    data: createDefaultData(),
-    setData: () => {
+  const Context = React.createContext<TContext<T>>([
+    createDefaultData(),
+    () => {
       return;
     },
-  });
+  ]);
 
   const Provider: React.FC = props => {
-    const [data, setData] = useState<T>(createDefaultData);
+    const state = useState<T>(createDefaultData);
 
-    return (
-      <Context.Provider value={{ data, setData }}>
-        {props.children}
-      </Context.Provider>
-    );
+    return <Context.Provider value={state}>{props.children}</Context.Provider>;
   };
 
   const useData = () => {
@@ -97,12 +81,7 @@ export const createContext = <T extends {}>(defaultData: T) => {
     if (!context) {
       throw new Error(`Context error: context must be used within a Provider`);
     }
-    const { data, setData } = context;
-
-    return {
-      data,
-      setData,
-    };
+    return context;
   };
 
   return {

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -29,13 +29,13 @@ export const createPersistContext = <T extends {}>({
   const Provider: React.FC<{
     persist?: boolean;
   }> = props => {
-    const persisted = usePersistStorage<T>(storageKey, createDefaultData, {
+    const [data, setData, restore] = usePersistStorage<T>(storageKey, createDefaultData, {
       persist: props.persist,
       version,
     });
 
     return (
-      <Context.Provider value={persisted}>{props.children}</Context.Provider>
+      <Context.Provider value={[data, setData, restore]}>{props.children}</Context.Provider>
     );
   };
 

--- a/src/utils/context.tsx
+++ b/src/utils/context.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import usePersistStorage from 'react-native-use-persist-storage';
+
+export type TPersistContext<T> = {
+  data: T;
+  setData: React.Dispatch<React.SetStateAction<T>>;
+  restored: boolean;
+};
+
+export const createPersistContext = <T extends {}>({
+  defaultData,
+  storageKey,
+  version = 0,
+}: {
+  defaultData: T;
+  storageKey: string;
+  version?: number;
+}) => {
+  const createDefaultData = () => defaultData;
+
+  const Context = React.createContext<TPersistContext<T>>({
+    data: createDefaultData(),
+    setData: () => {
+      return;
+    },
+    restored: false,
+  });
+
+  const Provider: React.FC<{
+    persist?: boolean;
+  }> = props => {
+    const [data, setData, restored] = usePersistStorage<T>(
+      storageKey,
+      createDefaultData,
+      {
+        persist: props.persist,
+        version,
+      },
+    );
+
+    return (
+      <Context.Provider value={{ data, setData, restored }}>
+        {props.children}
+      </Context.Provider>
+    );
+  };
+
+  const useData = () => {
+    const context = React.useContext(Context);
+    if (!context) {
+      throw new Error(
+        `Context error: context [${storageKey}] must be used within a Provider`,
+      );
+    }
+    const { data, setData, restored } = context;
+
+    return {
+      data,
+      setData,
+      restored,
+    };
+  };
+
+  return {
+    Provider,
+    Context,
+    useData,
+  };
+};
+
+export type TContext<T> = {
+  data: T;
+  setData: React.Dispatch<React.SetStateAction<T>>;
+};
+
+export const createContext = <T extends {}>(defaultData: T) => {
+  const createDefaultData = () => defaultData;
+  const Context = React.createContext<TContext<T>>({
+    data: createDefaultData(),
+    setData: () => {
+      return;
+    },
+  });
+
+  const Provider: React.FC = props => {
+    const [data, setData] = useState<T>(createDefaultData);
+
+    return (
+      <Context.Provider value={{ data, setData }}>
+        {props.children}
+      </Context.Provider>
+    );
+  };
+
+  const useData = () => {
+    const context = React.useContext(Context);
+    if (!context) {
+      throw new Error(`Context error: context must be used within a Provider`);
+    }
+    const { data, setData } = context;
+
+    return {
+      data,
+      setData,
+    };
+  };
+
+  return {
+    Provider,
+    Context,
+    useData,
+  };
+};


### PR DESCRIPTION
1. Abstract the create context code into `createContext` and `createPersistContext`
2. export the data hook directly. Originally when we want to use the context data, we need to import  the useContext and the context, now we can use data directly